### PR TITLE
init harrison-working-branch. Add new schema, NULL noise generator, 4 hr run time

### DIFF
--- a/app.py
+++ b/app.py
@@ -702,7 +702,7 @@ def control_generation(button_clicks, n_intervals, selected_language, selected_i
         if not status["running"] or not status["industry"]:
             raise dash.exceptions.PreventUpdate
         
-        if status['start_time'] and (time.time() - status['start_time']) > 3600:  # 1 hour limit
+        if status['start_time'] and (time.time() - status['start_time']) > (3600 * 4):  # 4 hour limit
             print("\nTime limit reached...")
             status["running"] = False
             status["industry"] = None

--- a/data_generators/base_generator.py
+++ b/data_generators/base_generator.py
@@ -146,12 +146,17 @@ class BaseGenerator(ABC):
     
     def _generate_value(self, col, col_def):
         """Base method for generating values based on data type."""
-        if isinstance(col_def, str):
-            dtype = col_def
-            format_spec = None
-        else:
+        # Check for null probability first
+        if isinstance(col_def, dict):
+            null_prob = col_def.get('null_probability', 0.0)
+            if random.random() < null_prob:
+                return None
+            
             dtype = col_def.get('type', 'string')
             format_spec = col_def.get('format')
+        else:
+            dtype = col_def
+            format_spec = None
             
         col_lower = col.lower()
         
@@ -184,7 +189,6 @@ class BaseGenerator(ABC):
             elif 'zip' in col_lower:
                 return self.fake.zipcode()
             elif 'contact' in col_lower and 'number' in col_lower:
-                # Generate a standard 10-digit phone number
                 return f"({self.fake.random_number(digits=3)}) {self.fake.random_number(digits=3)}-{self.fake.random_number(digits=4)}"
             elif 'email' in col_lower:
                 return self.fake.email()

--- a/schema/Energy/energy_emissions.yml
+++ b/schema/Energy/energy_emissions.yml
@@ -1,0 +1,40 @@
+table: energy_emissions
+type: fact
+num_rows: 1000
+columns:
+  plant_id:
+    type: int
+    null_probability: 0.0  # primary identifier should never be null
+  co2_emission_tonnes:
+    type: float
+    null_probability: 0.05  # 5% chance of being null
+  measurement_date:
+    type: datetime
+    null_probability: 0.0  # timestamps should generally not be null
+  fuel_type:
+    type: string
+    format: "natural_gas|coal|biomass|solar|wind"
+    null_probability: 0.02  # 2% chance of being null
+  region:
+    type: string
+    format: "NORTH|SOUTH|EAST|WEST|CENTRAL"
+    null_probability: 0.03  # 3% chance of being null
+  operational_status:
+    type: string
+    format: "operational|maintenance|offline"
+    null_probability: 0.01  # 1% chance of being null
+  temperature_celsius:
+    type: float
+    null_probability: 0.08  # 8% chance of being null
+data_quality_rules:
+  plant_id:
+    min_value: 1
+    max_value: 100
+  co2_emission_tonnes:
+    min_value: 0
+    max_value: 500
+    anomaly_percentage: 0.03
+  temperature_celsius:
+    min_value: -40
+    max_value: 60
+    anomaly_percentage: 0.035 


### PR DESCRIPTION
Added energy_emissions schema as a test schema for NULL noise generation. Modified base_generator.py to randomize NULL inputs. Also extended run-time of data generator to 4 hours.